### PR TITLE
Fix typo in "btthreadall" in gdb-macros

### DIFF
--- a/home/.bin/gdb-macros
+++ b/home/.bin/gdb-macros
@@ -84,7 +84,7 @@ end
 
 # print backtraces of all threads (based on 'all_list' all threads list)
 define btthreadall
-    btthreadlist all_list allelem
+    btthreadlist &all_list allelem
 end
 document btthreadall
     Print backtraces of all threads


### PR DESCRIPTION
Seems like there's a typo:
```sh
(gdb) btthreadlist all_list allelem
Attempt to take address of value not located in memory.
```

The original `gdb-macros` file in the pintos src is correct:

https://github.com/Berkeley-CS162/group0/blob/2d42339cde0c6cb1d0c916ddb6494345d04da1c6/src/misc/gdb-macros#L86-L88

